### PR TITLE
Create auto assignments for pr action

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+addReviewers: true
+addAssignees: author
+reviewers:
+  - MansurAliKoroglu
+  - UgurCanTiryaki
+numberOfReviewers: 1

--- a/.github/workflows/github-helpers.yaml
+++ b/.github/workflows/github-helpers.yaml
@@ -14,10 +14,10 @@ permissions:
   security-events: none
   statuses: none
 jobs:
-  auto-assignee-for-pr:
-    name: auto-assignee-for-pr
+  auto-assignments-for-pr:
+    name: auto-assignments-for-pr
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: toshimaru/auto-author-assign@v1.3.5
+      - uses: kentaro-m/auto-assign-action@v1.2.0

--- a/.github/workflows/github-helpers.yaml
+++ b/.github/workflows/github-helpers.yaml
@@ -1,7 +1,7 @@
 name: 'github-helpers'
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 permissions:
   actions: none
   checks: none


### PR DESCRIPTION
`auto-assignments-for-pr` action is created. It automatically adds reviewer to pr from the list of reviewers which is within `auto_assign.yml` configuration file, and automatically adds pr owner as assignee.

As this action also assigns pr owner as assignee, `auto-assignee-for-pr` action was deleted.