### PR TITLE
Fix mailto in footer and router view text color

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative text-white">
     <Header class="absolute w-full"></Header>
-    <router-view class="bg-gray-100"></router-view>
+    <router-view class="bg-gray-100 text-black"></router-view>
     <Footer />
   </div>
 </template>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -21,9 +21,9 @@
       ></a>
     </div>
     <div class="flex justify-center divide-x text-xl w-full">
-      <a href="mailto:ugurctiryaki@gmail.com" class="w-1/5 text-center"
-        >ugurctiryaki@gmail.com</a
-      >
+      <div class="w-1/5 text-center">
+        <a href="mailto:ugurctiryaki@gmail.com">ugurctiryaki@gmail.com</a>
+      </div>
       <span class="w-1/5 text-center">© 2021 Uğur Can Tiryaki</span>
     </div>
     <div>

--- a/src/components/HomeButton.vue
+++ b/src/components/HomeButton.vue
@@ -8,6 +8,7 @@
       rounded-3xl
       bg-rose-600
       hover:bg-rose-800
+      text-white
     "
     :to="buttonLink"
   >


### PR DESCRIPTION
## Description
- Fixed `mailto` link in the footer, which was clickable outside of its text, to be clickable just on its text.
- `router-view`'s text color was white which doesn't look good, I thought it would be better to change all `router-view` to `text-black`. But I needed to make some parts of website to keep using `text-white`.

## Checklist

- [x] My changes are documented
- [x] My changes are tested
